### PR TITLE
Allow using as CMAKE Submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(
   $<${v8_enable_concurrent_marking}:V8_CONCURRENT_MARKING>
 )
 
-set(D ${CMAKE_SOURCE_DIR}/v8)
+set(D ${PROJECT_SOURCE_DIR}/v8)
 
 #
 # d8


### PR DESCRIPTION
Do not use `CMAKE_SOURCE_DIR` as it references top-most CMAKE directory.
Use `PROJECT_SOURCE_DIR` which is for this project (wherever it is in the CMAKE tree).