### PR TITLE
Makes sure torque outputs are correctly timestamped.  Torque does not…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,6 +736,8 @@ add_custom_command(
     -o ${PROJECT_BINARY_DIR}/torque-generated
     -v8-root ${D}
     ${torque_files}
+  COMMAND
+    ${CMAKE_COMMAND} -E touch ${torque-outputs} ${torque_outputs}
   DEPENDS
     torque
     ${torque_dirs}


### PR DESCRIPTION
… update a file if its contents haven't changed. However, we need to rerun torque when torque itself changes. In this case, the timestamp of torque is updated but all torque_outputs still have the old timestamp and are NOT updated since their contents hasn't changed. This leaves us in the unfortunate position of rerunning torque (which changes nothing) on each build.

The solution is to make sure that all torque outputs get touched after torque is run. In the case where torque updates but no on-disk changes occur, we'll rebuild all torque outputs, but this is rarer.