### PR TITLE
Adds cmake/GNUtils.cmake. This contains utility routines for v8/CMake…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(GNUInstallDirs)
 
 include(CheckPythonModuleExists)
 include(GenerateBuiltinsList)
+include(GNUtils)
 
 check_python_module_exists(PYTHON_HAVE_MARKUPSAFE markupsafe)
 
@@ -61,6 +62,23 @@ string(CONCAT is-x64 $<OR:
 option(V8_ENABLE_CONCURRENT_MARKING "Enable concurrent marking" ON)
 option(V8_ENABLE_I18N "Enable Internationalization support")
 
+#
+# configs - holder for common configuration data
+#
+# GN passes around config objects that have common defines/flags/includes
+# that are common across many components. We emulate these in GNUtils.cmake
+#
+# The most common configs are:
+#   [no]exceptions - [disables]enables exceptions in components
+#   features - global defines relating to the product features.
+#   toolchain - global defines covering what is being used to build
+#
+# We could emulate this directly in cmake by clusters of
+# target_compile_definitions/target_compile_options/target_include_directories
+# but its a lot of typing and misses some of the key functionality
+# (relative vs absolute paths)
+#
+
 set(
   v8_defines
   $<${is-darwin}:V8_HAVE_TARGET_OS>
@@ -71,7 +89,7 @@ set(
   $<${is-win}:V8_TARGET_OS_WIN>
   $<${is-x64}:V8_TARGET_ARCH_X64>
   $<${is-win}:NOMINMAX>
-  $<$<OR:${is-win},${is-x64}>:V8_OS_WINX64>
+  $<$<AND:${is-win},${is-x64}>:V8_OS_WINX64>
   $<$<BOOL:${V8_ENABLE_CONCURRENT_MARKING}>:V8_CONCURRENT_MARKING>
   $<${is-win}:V8_OS_WIN32>
 )
@@ -91,21 +109,63 @@ set(enable-exceptions
   $<$<CXX_COMPILER_ID:GNU>:-fexceptions>)
 
 #
+# features is configuration data for v8 compile-time features
+#
+config_defines(features PRIVATE
+  V8_ARRAY_BUFFER_EXTENSION
+  )
+
+#
+# toolchain is configuration data relative to the current cpu and target cpu
+#
+config_defines(toolchain 
+  PRIVATE 
+  ${v8_defines}
+  $<${is-win}:/wd4245
+    /wd4267
+    /wd4324
+    /wd4701
+    /wd4702
+    /wd4703
+    /wd4709
+    /wd4714
+    /wd4715
+    /wd4718
+    /wd4723
+    /wd4724
+    /wd4800
+  >
+  )
+
+config_cflags(exceptions PRIVATE ${enable-exceptions})
+
+config_cflags(noexceptions PRIVATE ${disable-exceptions})
+config_defines(noexceptions PRIVATE $<${is-msvc}:_HAS_EXCEPTIONS=0>)
+
+config_include_dirs(internal_config_base PRIVATE . include ${PROJECT_BINARY_DIR})
+
+#
+# Consider making this PUBLIC/INTERFACE/install
+#
+config_include_dirs(external_config PRIVATE include ${PROJECT_BINARY_DIR}/include)
+
+#
 # d8
 #
 
-add_executable(
-  d8
-  $<${is-posix}:${D}/src/d8/d8-posix.cc>
-  $<${is-win}:${D}/src/d8/d8-windows.cc>
-  ${D}/src/d8/async-hooks-wrapper.cc
-  ${D}/src/d8/d8-console.cc
-  ${D}/src/d8/d8-js.cc
-  ${D}/src/d8/d8-platforms.cc
-  ${D}/src/d8/d8.cc)
+add_executable(d8)
+target_relative_sources(d8 ${D} PRIVATE
+  src/d8/async-hooks-wrapper.cc
+  src/d8/d8-console.cc
+  src/d8/d8-js.cc
+  src/d8/d8-platforms.cc
+  src/d8/d8.cc
+)
+target_conditional_relative_sources(d8 ${D} PRIVATE
+  $<${is-posix}:_S_> src/d8/d8-posix.cc
+  $<${is-win}:_S_> src/d8/d8-windows.cc
+  )
 
-target_compile_definitions(d8 PRIVATE $<${is-msvc}:_HAS_EXCEPTIONS=0>)
-target_compile_options(d8 PRIVATE ${disable-exceptions})
 target_include_directories(d8
   PUBLIC
     $<BUILD_INTERFACE:${D}/include>
@@ -114,6 +174,7 @@ target_include_directories(d8
     $<BUILD_INTERFACE:${D}>
 )
 
+target_config(d8 ${D} noexceptions internal_config_base)
 target_link_libraries(d8
   PRIVATE
     v8_base_without_compiler
@@ -126,33 +187,32 @@ target_link_libraries(d8
 add_library(v8-i18n-support OBJECT)
 set_property(TARGET v8-i18n-support PROPERTY EXCLUDE_FROM_ALL ON)
 
-list(APPEND i18n-sources
-  ${D}/src/builtins/builtins-intl.cc
-  ${D}/src/objects/intl-objects.cc
-  ${D}/src/objects/js-break-iterator.cc
-  ${D}/src/objects/js-collator.cc
-  ${D}/src/objects/js-date-time-format.cc
-  ${D}/src/objects/js-display-names.cc
-  ${D}/src/objects/js-list-format.cc
-  ${D}/src/objects/js-locale.cc
-  ${D}/src/objects/js-number-format.cc
-  ${D}/src/objects/js-plural-rules.cc
-  ${D}/src/objects/js-relative-time-format.cc
-  ${D}/src/objects/js-segment-iterator.cc
-  ${D}/src/objects/js-segmenter.cc
-  ${D}/src/runtime/runtime-intl.cc
-  ${D}/src/strings/char-predicates.cc)
+set(i18n-sources
+  src/builtins/builtins-intl.cc
+  src/objects/intl-objects.cc
+  src/objects/js-break-iterator.cc
+  src/objects/js-collator.cc
+  src/objects/js-date-time-format.cc
+  src/objects/js-display-names.cc
+  src/objects/js-list-format.cc
+  src/objects/js-locale.cc
+  src/objects/js-number-format.cc
+  src/objects/js-plural-rules.cc
+  src/objects/js-relative-time-format.cc
+  src/objects/js-segment-iterator.cc
+  src/objects/js-segmenter.cc
+  src/runtime/runtime-intl.cc
+  src/strings/char-predicates.cc
+  )
 
-target_sources(v8-i18n-support PRIVATE ${i18n-sources})
-target_compile_definitions(v8-i18n-support PRIVATE $<${is-msvc}:_HAS_EXCEPTIONS=0>)
-target_compile_options(v8-i18n-support PRIVATE ${disable-exceptions})
+target_relative_sources(v8-i18n-support ${D} PRIVATE ${i18n-sources})
+target_config(v8-i18n-support ${D} noexceptions internal_config_base)
 target_link_libraries(v8-i18n-support PRIVATE v8_torque_generated)
 
 target_include_directories(v8-i18n-support
   PRIVATE
-    ${D}
     ${D}/src/objects
-    ${D}/include)
+    )
 
 file(GLOB api-sources CONFIGURE_DEPENDS v8/src/api/*.cc)
 file(GLOB asmjs-sources CONFIGURE_DEPENDS v8/src/asmjs/*.cc)
@@ -187,6 +247,7 @@ list(REMOVE_ITEM builtin-sources
   ${D}/src/builtins/builtins-intl.cc)
 list(REMOVE_ITEM diagnostic-sources
   ${D}/src/diagnostics/unwinding-info-win64.cc)
+prepend_base_directory(${D} i18n-sources)
 list(REMOVE_ITEM object-sources ${i18n-sources})
 list(REMOVE_ITEM regexp-sources ${D}/src/regexp/gen-regexp-special-case.cc)
 list(REMOVE_ITEM runtime-sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,20 +121,23 @@ config_defines(features PRIVATE
 config_defines(toolchain 
   PRIVATE 
   ${v8_defines}
-  $<${is-win}:/wd4245
-    /wd4267
-    /wd4324
-    /wd4701
-    /wd4702
-    /wd4703
-    /wd4709
-    /wd4714
-    /wd4715
-    /wd4718
-    /wd4723
-    /wd4724
-    /wd4800
-  >
+  )
+config_cflags(toolchain
+  PRIVATE
+    $<${is-win}:/wd4245
+      /wd4267
+      /wd4324
+      /wd4701
+      /wd4702
+      /wd4703
+      /wd4709
+      /wd4714
+      /wd4715
+      /wd4718
+      /wd4723
+      /wd4724
+      /wd4800
+    >
   )
 
 config_cflags(exceptions PRIVATE ${enable-exceptions})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,12 +145,19 @@ config_cflags(exceptions PRIVATE ${enable-exceptions})
 config_cflags(noexceptions PRIVATE ${disable-exceptions})
 config_defines(noexceptions PRIVATE $<${is-msvc}:_HAS_EXCEPTIONS=0>)
 
-config_include_dirs(internal_config_base PRIVATE . include ${PROJECT_BINARY_DIR})
+config_include_dirs(internal_config_base ${D} PRIVATE
+  .
+  include
+  ${PROJECT_BINARY_DIR}
+  )
 
 #
 # Consider making this PUBLIC/INTERFACE/install
 #
-config_include_dirs(external_config PRIVATE include ${PROJECT_BINARY_DIR}/include)
+config_include_dirs(external_config ${D} PRIVATE
+  include
+  ${PROJECT_BINARY_DIR}/include
+  )
 
 #
 # d8

--- a/cmake/GNUtils.cmake
+++ b/cmake/GNUtils.cmake
@@ -1,0 +1,131 @@
+#
+#   BUILD.gn to CMakeLists.txt conversion macros
+#
+
+#
+# Prepends the base directory to relative paths in a list
+# leaving absolute paths alone.
+#
+function(prepend_base_directory base var)
+  set(_processed_list)
+  foreach(dir IN LISTS ${var})
+    if(IS_ABSOLUTE ${dir})
+      list(APPEND _processed_list ${dir})
+    else()
+      list(APPEND _processed_list ${base}/${dir})
+    endif()
+  endforeach()
+  set(${var} ${_processed_list} PARENT_SCOPE)
+endfunction()
+
+#
+# Adds a set of files as sources to a target. Relative paths are
+# qualified by a base directory
+#
+function(target_relative_sources target base vis)
+  set(_sources ${ARGN})
+  prepend_base_directory(${base} _sources)
+  #message("target_relative_sources ${target} ${vis} ${_sources}")
+  target_sources(${target} ${vis} ${_sources})
+endfunction()
+
+#
+# Adds generator-condition/file pairs to a source. files that are
+# relative are qualified by a base directory
+#
+function(target_conditional_relative_sources target base vis cond src)
+  #message("target_conditional_relative_sources ${target} ${base} ${vis} ${cond} ${src}")
+  set(_sources ${src})
+  prepend_base_directory(${base} _sources)
+  string(REPLACE _S_ "${_sources}" _replaced ${cond})
+  #message("target_conditional_relative_sources ${target} ${vis} ${_replaced}")
+  target_sources(${target} ${vis} ${_replaced})
+  if (ARGN)
+    target_conditional_relative_sources( ${target} ${base} ${vis} ${ARGN})
+  endif()
+endfunction()
+
+#
+# Configs are containers for defines/flags/include-directories. Configs
+# are applied after target-specific defines/flags/include-directories are
+# added to executables/libraries.
+#
+# BUGBUG - in GN there is a hierarchy where config information is inherited
+# akin to cmake's PUBLIC/PRIVATE defines/includes/etc. The implementation
+# does NOT do this, although it wouldn't be hard.
+#
+# One difficulty is that since we're doing this via variables, the ordering
+# of config construction in CMakeLists.txt is important.
+#
+#   X is a config
+#       X_defined indicates that X has been declared
+#       X_<VIS>_defines is a set of definitions
+#       X_<VIS>_cflags are the c flags used for X
+#       X_<VIS>_include_dirs are the include directories
+#
+# Two special configs, features and toolchain are always applied first
+# to a target
+#
+
+#
+# Add defines to a named config
+#
+function(config_defines config vis)
+  #message("config_defines ${config} ${vis} ${ARGN}")
+  #message("${config}_${vis}_defines")
+  set(_list ${${config}_${vis}_defines} ${ARGN})
+  set(${config}_${vis}_defines ${_list} PARENT_SCOPE)
+  set(${config}_defined 1 PARENT_SCOPE)
+endfunction()
+
+#
+# Add cflags to a named config
+#
+function(config_cflags config vis)
+  set(_list ${${config}_${vis}_cflags} ${ARGN})
+  set(${config}_${vis}_cflags ${_list} PARENT_SCOPE)
+  set(${config}_defined 1 PARENT_SCOPE)
+endfunction()
+
+#
+# Add include dirs to a named config
+#
+function(config_include_dirs config vis)
+  #message( "config_include_dirs ${config} ${dirs} ${ARGN}")
+  set(_list ${${config}_${vis}_include_dirs} ${ARGN})
+  set(${config}_${vis}_include_dirs ${_list} PARENT_SCOPE)
+  #message(" ${config}_${vis}_include_dirs ${${config}_${vis}_include_dirs}")
+  set(${config}_defined 1 PARENT_SCOPE)
+endfunction()
+
+#
+# Adds config info to a target. Relative paths in the include directories
+# are qualified by a base directory
+#
+function(target_config target base)
+  #message("target_config ${target} ${ARGN}")
+  set(_configs features toolchain ${ARGN})
+  foreach(config IN LISTS _configs)
+    if(NOT ${config}_defined EQUAL 1)
+      message("WARNING: ${config} not defined")
+    endif()
+    _target_config_vis(${target} ${base} ${config} PUBLIC)
+    _target_config_vis(${target} ${base} ${config} PRIVATE)
+  endforeach()
+endfunction()
+
+function(_target_config_vis target base config vis)
+  if(DEFINED ${config}_${vis}_defines)
+    #message(" target_compile_definitions(${target} ${vis} ${${config}_${vis}_defines})")
+    target_compile_definitions(${target} ${vis} ${${config}_${vis}_defines})
+  endif()
+  if(DEFINED ${config}_${vis}_cflags)
+    #message(" target_compile_options(${target} ${${config}_${vis}_cflags})")
+    target_compile_options(${target} ${vis} ${${config}_${vis}_cflags})
+  endif()
+  if(DEFINED ${config}_${vis}_include_dirs)
+    #message(" target_include_directories(${target} ${${config}_${vis}_include_dirs})")
+    prepend_base_directory(${base} ${config}_${vis}_include_dirs)
+    target_include_directories(${target} ${vis} ${${config}_${vis}_include_dirs})
+  endif()
+endfunction()

--- a/cmake/GNUtils.cmake
+++ b/cmake/GNUtils.cmake
@@ -90,9 +90,10 @@ endfunction()
 #
 # Add include dirs to a named config
 #
-function(config_include_dirs config vis)
+function(config_include_dirs config base vis)
   #message( "config_include_dirs ${config} ${dirs} ${ARGN}")
   set(_list ${${config}_${vis}_include_dirs} ${ARGN})
+  prepend_base_directory(${base} _list)
   set(${config}_${vis}_include_dirs ${_list} PARENT_SCOPE)
   #message(" ${config}_${vis}_include_dirs ${${config}_${vis}_include_dirs}")
   set(${config}_defined 1 PARENT_SCOPE)


### PR DESCRIPTION
Adds cmake/GNUtils.cmake to streamline CMakeLists.txt

Updates v8/CMakeLists.txt to utilize the GNUtils routines for the d8 and v8-i18n-support targets as a sample. Details:

Creates six configs (toolchain, features, exceptions, noexceptions, internal_config_base, external_config) to encapsulate settings for individual targets.  This removes the need to set the same compile definitions/compile options/include directories on multiple targets

d8:
  - removes the explicit ${D}/ in front of all paths and use target_relative_sources to add these paths
  - uses target_conditional_relative_sources to add generator-conditioned relative files to the target
  - uses target_config to compile with noexceptions and internal_config_base. In addition, features and toolchain are also added

v8-i18n-support:
  - removes ${D}/ on all the input sources
  - uses target_relative_sources to add ${D}-based sources to the target
  - uses target_config which adds (via internal_config_base) the v8 default of ".", "include", and ${PROJECT_BINARY_DIR} to the include paths. Relative paths are qualified from ${D}

Ben -- of the two sets of changes (target relative source routines and configs), I consider the configs change the most important. It allows setting of configuration defines/flags/includes in one place that get reasonably applied to targets.

But, I'm open to discussion!