### PR TITLE
Use precompiled headers to improve compile times.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/MSVC.cmake
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 project(V8 LANGUAGES CXX C ASM)
 
+set(USE_PRECOMPILED_HEADERS 0)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0") 
+set(USE_PRECOMPILED_HEADERS 1)
+endif()
+
 if(MSVC)
   enable_language(ASM_MASM)
   set_property(SOURCE ${PROJECT_BINARY_DIR}/embedded.S PROPERTY LANGUAGE ASM_MASM)
@@ -306,6 +311,12 @@ if (WIN32)
   endif()
 endif()
 
+#if using preompiled headers, _WIN32_WINNT needs to be set globally or compilation fails.
+set(v8_define_winnt)
+if (WIN32)
+set(v8_define_winnt -DUNICODE -D_WIN32_WINNT=${windows-version})
+endif()
+
 set_property(SOURCE v8/src/diagnostics/unwinding-info-win64.cc
   APPEND PROPERTY
     COMPILE_DEFINITIONS
@@ -313,7 +324,7 @@ set_property(SOURCE v8/src/diagnostics/unwinding-info-win64.cc
       _WIN32_WINNT=${windows-version}
 )
 
-target_compile_definitions(v8_base_without_compiler PRIVATE ${v8_defines} $<${is-msvc}:_HAS_EXCEPTIONS=0>)
+target_compile_definitions(v8_base_without_compiler PRIVATE ${v8_defines} ${v8_define_winnt} $<${is-msvc}:_HAS_EXCEPTIONS=0>)
 target_compile_options(v8_base_without_compiler PRIVATE ${disable-exceptions})
 
 target_include_directories(v8_base_without_compiler
@@ -661,11 +672,9 @@ add_library(v8_libbase STATIC
   $<${is-posix}:v8/src/base/platform/platform-posix.cc>
 )
 
-set_property(SOURCE v8/src/base/utils/random-number-generator.cc
-  APPEND PROPERTY COMPILE_DEFINITIONS _CRT_RAND_S
-)
-
-target_compile_definitions(v8_libbase PRIVATE $<${is-win}:UNICODE> $<${is-msvc}:_HAS_EXCEPTIONS=0>)
+# previously, _CRT_RAND_S was defined only for random-number-generator.cc
+# This prevents precompiled headers working well - so apply globally instead.
+target_compile_definitions(v8_libbase PRIVATE $<${is-win}:UNICODE> $<${is-msvc}:_HAS_EXCEPTIONS=0> _CRT_RAND_S)
 target_compile_options(v8_libbase PRIVATE ${disable-exceptions})
 target_include_directories(v8_libbase PRIVATE ${PROJECT_SOURCE_DIR}/v8)
 target_link_libraries(v8_libbase
@@ -866,3 +875,269 @@ target_include_directories(v8-adler32
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/v8/third_party/zlib>
 )
+
+
+# Precompiled headers to reduce lengthy compile times, where available (e.g. MSVC)
+if(${USE_PRECOMPILED_HEADERS}) 
+  # cant include everything in base
+  set(H_BASE 
+    "include/precomp_stl.h"
+    "v8/src/base/compiler-specific.h"
+    "v8/src/base/memory.h"
+    "v8/src/base/build_config.h"
+    "v8/src/base/atomicops.h"
+    "v8/src/base/base-export.h"
+    "v8/src/base/bits.h"
+    "v8/src/base/bounds.h"
+    "v8/src/base/bounded-page-allocator.h"
+    "v8/src/base/file-utils.h"
+    "v8/src/base/flags.h"
+    "v8/src/base/functional.h"
+    "v8/src/base/lazy-instance.h"
+    "v8/src/base/v8-fallthrough.h"
+  )
+  file(GLOB H_API "v8/src/api/*.h")
+  file(GLOB H_BUILTINS "v8/src/builtins/*.h")
+  file(GLOB H_COMMON "v8/src/common/*.h")
+  file(GLOB H_COMPILER "v8/src/compiler/*.h")
+  file(GLOB H_FLAGS "v8/src/flags/*.h")
+  file(GLOB H_HEAP "v8/src/heap/*.h")
+  file(GLOB H_LOGGING "v8/src/logging/*.h")
+  file(GLOB H_REGEXP "v8/src/regexp/*.h")
+  file(GLOB H_RUNTIME "v8/src/runtime/*.h")
+  file(GLOB H_STRINGS "v8/src/strings/*.h")
+  file(GLOB H_UTILS "v8/src/utils/*.h")
+  file(GLOB H_WASM "v8/src/wasm/*.h")
+
+  # Can't GLOB this one..
+  set(H_OBJECTS 
+    "v8/src/objects/compilation-cache-inl.h"
+    "v8/src/objects/elements.h"
+    "v8/src/objects/heap-number-inl.h"
+    "v8/src/objects/objects.h"
+    "v8/src/objects/objects-inl.h"
+    "v8/src/objects/slots.h"    
+    "v8/src/objects/smi.h"
+    "v8/src/objects/string.h"
+    "v8/src/objects/visitors.h"
+  )
+  set(H_PRECOMP 
+    ${H_BASE}
+    ${H_BUILTINS}
+    ${H_API}
+    ${H_COMMON}
+    ${H_COMPILER}
+    ${H_HEAP}
+    ${H_LOGGING}
+    ${H_OBJECTS}
+    ${H_REGEXP}
+    ${H_RUNTIME}
+    ${H_STRINGS}
+    ${H_UTILS}
+    ${H_WASM}
+    )
+  target_precompile_headers(v8_libplatform PRIVATE 
+    ${H_BASE}
+    "v8/src/libplatform/default-foreground-task-runner.h"
+    "v8/src/libplatform/default-job.h"
+    "v8/src/libplatform/default-worker-threads-task-runner.h"
+  )
+  target_precompile_headers(v8_libbase PRIVATE ${H_BASE})
+  target_precompile_headers(bytecode_builtins_list_generator PRIVATE ${H_BASE})
+
+  target_precompile_headers(v8_base_without_compiler PRIVATE   
+      "v8/include/v8.h"
+      "v8/include/v8config.h"
+      "v8/src/common/globals.h"
+      "v8/src/objects/js-array-buffer.h"
+      ${H_BASE}
+      ${H_BUILTINS}
+      ${H_API}
+      ${H_UTILS}
+      ${H_WASM}
+  )
+  target_precompile_headers(v8_initializers PRIVATE ${H_BASE})
+  target_precompile_headers(v8_compiler PRIVATE ${H_PRECOMP})
+  target_precompile_headers(mksnapshot PRIVATE ${H_PRECOMP})
+  
+  # Some surprising issues with explicit template instantiations
+  # going on for torque build if files in v8/src/torque included in PCH.
+  target_precompile_headers(torque
+     PRIVATE
+     ${H_BASE}
+     #${H_COMMON}
+  )
+  target_precompile_headers(v8_torque_generated PRIVATE ${H_PRECOMP}
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/aggregate-error-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-copywithin-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-every-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-filter-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-find-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-findindex-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-foreach-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-from-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-isarray-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-join-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-lastindexof-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-map-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-of-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-reduce-right-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-reduce-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-reverse-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-shift-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-slice-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-some-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-splice-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-unshift-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/arraybuffer-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/base-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/bigint-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/boolean-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/builtins-string-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/cast-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/collections-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/console-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/constructor-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/conversion-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/convert-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/data-view-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/finalization-registry-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/frame-arguments-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/frames-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/function-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/growable-fixed-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/ic-callable-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/ic-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/internal-coverage-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/internal-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/iterator-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/math-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/number-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/object-fromentries-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/object-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-abstract-operations-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-all-element-closure-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-all-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-any-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-constructor-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-finally-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-jobs-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-misc-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-race-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-reaction-job-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-resolve-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/promise-then-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-constructor-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-delete-property-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-get-property-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-get-prototype-of-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-has-property-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-is-extensible-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-prevent-extensions-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-revocable-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-revoke-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-set-property-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-set-prototype-of-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/proxy-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/reflect-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-exec-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-match-all-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-match-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-replace-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-search-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-source-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-split-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-test-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/regexp-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-endswith-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-html-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-iterator-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-pad-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-repeat-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-replaceall-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-slice-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-startswith-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-substr-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/string-substring-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/symbol-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/torque-internal-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-createtypedarray-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-entries-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-every-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-filter-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-find-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-findindex-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-foreach-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-from-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-keys-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-of-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-reduce-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-reduceright-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-set-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-slice-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-some-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-sort-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-subarray-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-values-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/typed-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/wasm-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/builtins/weak-ref-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/allocation-site-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/api-callbacks-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/arguments-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/cell-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/code-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/contexts-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/data-handler-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/debug-objects-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/descriptor-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/embedder-data-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/feedback-cell-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/feedback-vector-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/fixed-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/foreign-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/free-space-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/heap-number-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/heap-object-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-array-buffer-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-collection-iterator-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-collection-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-generator-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-objects-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-promise-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-proxy-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-regexp-string-iterator-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-regexp-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/js-weak-refs-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/literal-objects-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/map-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/microtask-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/module-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/name-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/oddball-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/ordered-hash-table-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/primitive-heap-object-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/promise-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/property-array-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/property-cell-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/property-descriptor-object-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/prototype-info-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/regexp-match-info-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/scope-info-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/script-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/shared-function-info-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/source-text-module-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/stack-frame-info-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/string-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/struct-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/synthetic-module-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/template-objects-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/objects/template-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/ic/handler-configuration-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/src/wasm/wasm-objects-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/test/torque/test-torque-tq-csa.h"
+    "${PROJECT_BINARY_DIR}/torque-generated/third_party/v8/builtins/array-sort-tq-csa.h"
+  )
+endif()

--- a/include/precomp_stl.h
+++ b/include/precomp_stl.h
@@ -1,0 +1,16 @@
+#include <algorithm>
+#include <cstring>
+#include <deque>
+#include <map>
+#include <memory>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <ostream>
+#include <queue>
+#include <streambuf>
+#include <string>
+#include <type_traits>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>


### PR DESCRIPTION
Drastic improvement to compile time with MSVC2019.  You may want to adjust the way that USE_PRECOMPILED_HEADERS gets set to restrict the compilers it applies to.  I have only tried this with MSVC.  I believe GCC implements PCH these days.  Not sure r.e. clang -- I think it does a good job without them.