### PR TITLE
Fixes issue where linux arm64 is not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(is-msvc $<CXX_COMPILER_ID:MSVC>)
 # FIXME obviously
 set(is-arm 0)
 set(is-arm64 0)
-if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
   set(is-arm64 1)
 endif ()
 set(is-ia32 0)


### PR DESCRIPTION
Adds arch64 to the list of arm64 devices.

Previously, arm64 was only defined as `arm64`, which only matches modern macOS on apple silicon.

As it turns out, there other arm64 devices besides apple silicon, and being able to compile against them is actually kind of nice.  This PR adds detection for `aarch64`, which is also considered `arm64` and allows v8 to compile and run.

also fixes #70 
