### PR TITLE
:bug: Fixed v8_torque_generated failing to build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,8 +999,11 @@ target_include_directories(v8_torque_generated
     ${PROJECT_SOURCE_DIR}/v8
 )
 
-# The torque-outputs and torque_outputs variables can have too many characters on Windows to be executed on the command line, so we have to write it to a temporary file and execute that 
-file(WRITE "${PROJECT_BINARY_DIR}/touch_torque_outputs.cmake" "file(TOUCH ${torque-outputs};${torque_outputs})")
+# The torque-outputs and torque_outputs variables can have too many characters
+# on Windows to be executed on the command line, so we have to write it to a
+# temporary file and execute that 
+file(WRITE "${PROJECT_BINARY_DIR}/touch_torque_outputs.cmake"
+           "file(TOUCH ${torque-outputs};${torque_outputs})")
 
 add_custom_command(
   COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,6 +999,9 @@ target_include_directories(v8_torque_generated
     ${PROJECT_SOURCE_DIR}/v8
 )
 
+# The torque-outputs and torque_outputs variables can have too many characters on Windows to be executed on the command line, so we have to write it to a temporary file and execute that 
+file(WRITE "${PROJECT_BINARY_DIR}/touch_torque_outputs.cmake" "file(TOUCH ${torque-outputs};${torque_outputs})")
+
 add_custom_command(
   COMMAND
     torque
@@ -1006,7 +1009,7 @@ add_custom_command(
     -v8-root ${PROJECT_SOURCE_DIR}/v8
     ${torque_files}
   COMMAND
-    ${CMAKE_COMMAND} -E touch ${torque-outputs} ${torque_outputs}
+    ${CMAKE_COMMAND} -P ${PROJECT_BINARY_DIR}/touch_torque_outputs.cmake
   DEPENDS
     torque
     ${torque_dirs}


### PR DESCRIPTION
The torque-outputs and torque_outputs variables can have too many characters on Windows to be executed on the command line, so we have to write it to a temporary file and execute that

Fixes #67
Fixes #42